### PR TITLE
updating to the latest jandex (2.0.1.Final)

### DIFF
--- a/jandex/build.gradle
+++ b/jandex/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    compile 'org.jboss:jandex:2.0.0.Beta1'
+    compile 'org.jboss:jandex:2.0.1.Final'
 }


### PR DESCRIPTION
Minor change to use a non-beta version of Jandex.